### PR TITLE
Refactor selectors into managers and fix template/layout issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 # Python
 __pycache__/
 *.py[cod]
-*.sqlite3
-
-# Django
-db.sqlite3
 
 # Virtual environments
 venv/

--- a/properties/managers.py
+++ b/properties/managers.py
@@ -1,8 +1,42 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
 
 from django.db import models
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
+
+
+def _parse_date(date_string):
+    if not date_string:
+        return None
+    try:
+        return datetime.strptime(date_string, "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_positive_int(value, minimum=1):
+    if value in (None, ""):
+        return None
+    try:
+        parsed_value = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed_value < minimum:
+        return None
+    return parsed_value
+
+
+def _parse_non_negative_decimal(value):
+    if value in (None, ""):
+        return None
+    try:
+        parsed_value = Decimal(value)
+    except (TypeError, InvalidOperation):
+        return None
+    if parsed_value < 0:
+        return None
+    return parsed_value
 
 
 class PropertyQuerySet(models.QuerySet):
@@ -51,6 +85,64 @@ class PropertyQuerySet(models.QuerySet):
     def recent(self, days=7, start_date=None, end_date=None):
         limit_date = timezone.now() - timedelta(days=days)
         return self.available(start_date, end_date).filter(created_at__gte=limit_date)
+
+    def detail(self, pk):
+        return self.with_owner().filter(pk=pk).first()
+
+    def search(self, filters=None):
+        from .services import filter_properties_by_availability
+
+        filters = filters or {}
+        queryset = self.with_owner()
+
+        search_term = filters.get("q", "").strip()
+        city = filters.get("city", "").strip()
+        listing_type = filters.get("listing_type", "").strip()
+        min_price = _parse_non_negative_decimal(filters.get("min_price"))
+        max_price = _parse_non_negative_decimal(filters.get("max_price"))
+        rooms = _parse_positive_int(filters.get("rooms"), minimum=1)
+        bathrooms = _parse_positive_int(filters.get("bathrooms"), minimum=1)
+        capacity = _parse_positive_int(filters.get("capacity"), minimum=1)
+        check_in = _parse_date(filters.get("check_in"))
+        check_out = _parse_date(filters.get("check_out"))
+
+        if search_term:
+            queryset = queryset.filter(
+                Q(title__icontains=search_term)
+                | Q(description__icontains=search_term)
+                | Q(address__icontains=search_term)
+                | Q(city__icontains=search_term)
+                | Q(owner__user__first_name__icontains=search_term)
+                | Q(owner__user__last_name__icontains=search_term)
+            )
+
+        if city:
+            queryset = queryset.filter(
+                Q(city__icontains=city) | Q(address__icontains=city)
+            )
+
+        if listing_type:
+            queryset = queryset.filter(listing_type=listing_type)
+
+        if min_price is not None:
+            queryset = queryset.filter(price__gte=min_price)
+
+        if max_price is not None:
+            queryset = queryset.filter(price__lte=max_price)
+
+        if rooms is not None:
+            queryset = queryset.filter(rooms__gte=rooms)
+
+        if bathrooms is not None:
+            queryset = queryset.filter(bathrooms__gte=bathrooms)
+
+        if capacity is not None:
+            queryset = queryset.filter(capacity__gte=capacity)
+
+        queryset = queryset.available(check_in, check_out)
+        queryset = filter_properties_by_availability(queryset, check_in, check_out)
+
+        return queryset.order_by("-created_at")
 
 
 class PropertyManager(models.Manager.from_queryset(PropertyQuerySet)):

--- a/properties/models.py
+++ b/properties/models.py
@@ -70,13 +70,28 @@ class Property(models.Model):
 
         return blocked_dates
 
-    def has_sale_contract(self):
+    def has_sale_contract(self, buyer=None):
         from transactions.models import Contract
 
-        return Contract.objects.filter(
+        contracts = Contract.objects.filter(
             property=self,
             type=Contract.TYPE_SALE,
-        ).exists()
+        )
+        if buyer is not None:
+            contracts = contracts.filter(tenant=buyer)
+        return contracts.exists()
+
+    def can_be_accessed_by(self, user):
+        if not self.has_sale_contract():
+            return True
+
+        if not getattr(user, "is_authenticated", False):
+            return False
+
+        if self.owner and self.owner.user_id == user.id:
+            return True
+
+        return self.has_sale_contract(buyer=user)
 
     def has_approved_booking_overlap(self, start_date, end_date):
         if self.listing_type == "sale":
@@ -140,6 +155,22 @@ class SavedPropertyQuerySet(models.QuerySet):
 
     def wishlist(self):
         return self.with_related().filter(property_obj__listing_type="sale")
+
+    def for_user(self, user):
+        return self.filter(user=user)
+
+    def ids_for_user(self, user):
+        if not getattr(user, "is_authenticated", False):
+            return set()
+        return set(
+            self.filter(user=user).values_list("property_obj_id", flat=True)
+        )
+
+    def favorites_for(self, user):
+        return self.favorites().filter(user=user).order_by("-created_at")
+
+    def wishlist_for(self, user):
+        return self.wishlist().filter(user=user).order_by("-created_at")
 
 
 class SavedProperty(models.Model):

--- a/properties/selectors.py
+++ b/properties/selectors.py
@@ -1,124 +1,21 @@
-from datetime import datetime
-from decimal import Decimal, InvalidOperation
-
-from django.db.models import Q
-
 from .models import Property, SavedProperty
-from .services import filter_properties_by_availability
-
-
-def _parse_date(date_string):
-    if not date_string:
-        return None
-
-    try:
-        return datetime.strptime(date_string, "%Y-%m-%d").date()
-    except (TypeError, ValueError):
-        return None
-
-
-def _parse_positive_int(value, minimum=1):
-    if value in (None, ""):
-        return None
-
-    try:
-        parsed_value = int(value)
-    except (TypeError, ValueError):
-        return None
-
-    if parsed_value < minimum:
-        return None
-
-    return parsed_value
-
-
-def _parse_non_negative_decimal(value):
-    if value in (None, ""):
-        return None
-
-    try:
-        parsed_value = Decimal(value)
-    except (TypeError, InvalidOperation):
-        return None
-
-    if parsed_value < 0:
-        return None
-
-    return parsed_value
 
 
 def get_property_detail(pk):
-    return Property.objects.with_owner().filter(pk=pk).first()
+    return Property.objects.detail(pk=pk)
 
 
 def get_saved_property_ids(user):
-    if not getattr(user, "is_authenticated", False):
-        return set()
-
-    return set(
-        SavedProperty.objects.filter(user=user).values_list(
-            "property_obj_id",
-            flat=True,
-        )
-    )
+    return SavedProperty.objects.ids_for_user(user)
 
 
 def get_user_favorites(user):
-    return SavedProperty.objects.favorites().filter(user=user).order_by("-created_at")
+    return SavedProperty.objects.favorites_for(user)
 
 
 def get_user_wishlist(user):
-    return SavedProperty.objects.wishlist().filter(user=user).order_by("-created_at")
+    return SavedProperty.objects.wishlist_for(user)
 
 
 def list_available_properties(filters=None):
-    filters = filters or {}
-
-    queryset = Property.objects.with_owner()
-
-    search_term = filters.get("q", "").strip()
-    city = filters.get("city", "").strip()
-    listing_type = filters.get("listing_type", "").strip()
-    min_price = _parse_non_negative_decimal(filters.get("min_price"))
-    max_price = _parse_non_negative_decimal(filters.get("max_price"))
-    rooms = _parse_positive_int(filters.get("rooms"), minimum=1)
-    bathrooms = _parse_positive_int(filters.get("bathrooms"), minimum=1)
-    capacity = _parse_positive_int(filters.get("capacity"), minimum=1)
-    check_in = _parse_date(filters.get("check_in"))
-    check_out = _parse_date(filters.get("check_out"))
-
-    if search_term:
-        queryset = queryset.filter(
-            Q(title__icontains=search_term)
-            | Q(description__icontains=search_term)
-            | Q(address__icontains=search_term)
-            | Q(city__icontains=search_term)
-            | Q(owner__user__first_name__icontains=search_term)
-            | Q(owner__user__last_name__icontains=search_term)
-        )
-
-    if city:
-        queryset = queryset.filter(Q(city__icontains=city) | Q(address__icontains=city))
-
-    if listing_type:
-        queryset = queryset.filter(listing_type=listing_type)
-
-    if min_price is not None:
-        queryset = queryset.filter(price__gte=min_price)
-
-    if max_price is not None:
-        queryset = queryset.filter(price__lte=max_price)
-
-    if rooms is not None:
-        queryset = queryset.filter(rooms__gte=rooms)
-
-    if bathrooms is not None:
-        queryset = queryset.filter(bathrooms__gte=bathrooms)
-
-    if capacity is not None:
-        queryset = queryset.filter(capacity__gte=capacity)
-
-    queryset = queryset.available(check_in, check_out)
-    queryset = filter_properties_by_availability(queryset, check_in, check_out)
-
-    return queryset.order_by("-created_at")
+    return Property.objects.search(filters)

--- a/templates/auth/password_reset.html
+++ b/templates/auth/password_reset.html
@@ -1,8 +1,7 @@
 {% extends 'base.html' %}
 {% block title %}
     Reset Password – StayHome
-{% endblock
-%}
+{% endblock %}
 {% load static i18n %}
 {% block content %}
     <div class="page">

--- a/templates/auth/password_reset_complete.html
+++ b/templates/auth/password_reset_complete.html
@@ -1,14 +1,14 @@
 {% extends 'base.html' %}
 {% block title %}
-    Password Updated – StayHome{%
-    endblock %}
-    {% load static i18n %}
-    {% block content %}
-        <div class="page">
-            <div class="card auth-card" style="text-align: center">
-                <h2 class="section-title">{% trans "Password updated" %}</h2>
-                <p class="section-sub">{% trans "You can now log in with your new password." %}</p>
-                <a href="{% url 'login' %}" class="btn-list full-width">{% trans "Go to login" %}</a>
-            </div>
+    Password Updated – StayHome
+{% endblock %}
+{% load static i18n %}
+{% block content %}
+    <div class="page">
+        <div class="card auth-card" style="text-align: center">
+            <h2 class="section-title">{% trans "Password updated" %}</h2>
+            <p class="section-sub">{% trans "You can now log in with your new password." %}</p>
+            <a href="{% url 'login' %}" class="btn-list full-width">{% trans "Go to login" %}</a>
         </div>
-    {% endblock %}
+    </div>
+{% endblock %}

--- a/templates/auth/password_reset_done.html
+++ b/templates/auth/password_reset_done.html
@@ -6,8 +6,7 @@
         <div class="card auth-card" style="text-align: center">
             <h2 class="section-title">{% trans "Check your email" %}</h2>
             <p class="section-sub">
-                {% trans "If the email exists, we sent you a link to reset your password."
-                %}
+                {% trans "If the email exists, we sent you a link to reset your password." %}
             </p>
             <p class="auth-footer">
                 <a href="{% url 'login' %}">{% trans "Back to login" %}</a>

--- a/templates/comunication/conversation_detail.html
+++ b/templates/comunication/conversation_detail.html
@@ -5,8 +5,7 @@
     StayHome
 {% endblock %}
 {% block nav_messages %}active{% endblock %}
-{% block
-    content %}
+{% block content %}
     <section class="messages-layout">
         <!-- SIDEBAR -->
         <div class="messages-sidebar">
@@ -19,11 +18,9 @@
                         <div class="conversation-top">
                             <strong>
                                 {% if row.other_user.get_full_name %}
-                                    {{
-                                    row.other_user.get_full_name }}
+                                    {{ row.other_user.get_full_name }}
                                 {% else %}
-                                    {{ row.other_user.email
-                                    }}
+                                    {{ row.other_user.email }}
                                 {% endif %}
                             </strong>
                             {% if row.unread_count %}<span class="conversation-badge">{{ row.unread_count }}</span>{% endif %}
@@ -31,50 +28,51 @@
                         <small class="conversation-property">{{ row.property.title }}</small>
                         <p class="conversation-preview">
                             {% if row.last_message %}
-                                {{ row.last_message|truncatechars:40 }} {%
-                                endif %}
-                            </p>
-                        </div>
-                    </a>
+                                {{ row.last_message|truncatechars:40 }}
+                            {% endif %}
+                        </p>
+                    </div>
+                </a>
+            {% endfor %}
+        </div>
+        <!-- CHAT -->
+        <div class="messages-chat">
+            <header class="chat-header">
+                <div class="chat-user">
+                    <div class="conversation-avatar">👤</div>
+                    <div>
+                        <strong>
+                            {% if other_user.get_full_name %}
+                                {{ other_user.get_full_name }}
+                            {% else %}
+                                {{ other_user.email }}
+                            {% endif %}
+                        </strong>
+                        <p class="chat-property">{% trans "About:" %} {{ conversation.property.title }}</p>
+                    </div>
+                </div>
+                <a href="{% url 'properties:property_detail' conversation.property.pk %}">{% trans "View property" %}</a>
+            </header>
+            <!-- MESSAGES -->
+            <div class="chat-messages">
+                {% for message in messages_list %}
+                    <div class="chat-message {% if message.sender == request.user %}own{% else %}other{% endif %}">
+                        <div class="chat-bubble">{{ message.content }}</div>
+                        <small class="chat-time">{{ message.created_at|date:"M d, Y H:i" }}</small>
+                    </div>
                 {% endfor %}
             </div>
-            <!-- CHAT -->
-            <div class="messages-chat">
-                <header class="chat-header">
-                    <div class="chat-user">
-                        <div class="conversation-avatar">👤</div>
-                        <div>
-                            <strong>
-                                {% if other_user.get_full_name %}
-                                    {{ other_user.get_full_name }} {%
-                                    else %} {{ other_user.email }}
-                                {% endif %}
-                            </strong>
-                            <p class="chat-property">{% trans "About:" %} {{ conversation.property.title }}</p>
-                        </div>
-                    </div>
-                    <a href="{% url 'properties:property_detail' conversation.property.pk %}">{% trans "View property" %}</a>
-                </header>
-                <!-- MESSAGES -->
-                <div class="chat-messages">
-                    {% for message in messages_list %}
-                        <div class="chat-message {% if message.sender == request.user %}own{% else %}other{% endif %}">
-                            <div class="chat-bubble">{{ message.content }}</div>
-                            <small class="chat-time">{{ message.created_at|date:"M d, Y H:i" }}</small>
-                        </div>
-                    {% endfor %}
-                </div>
-                <!-- INPUT -->
-                <form method="post"
-                      action="{% url 'comunication:send_message' conversation.pk %}"
-                      class="chat-input">
-                    {% csrf_token %}
-                    <input type="text"
-                           name="content"
-                           placeholder="Type your message..."
-                           required />
-                    <button type="submit">➤</button>
-                </form>
-            </div>
-        </section>
-    {% endblock %}
+            <!-- INPUT -->
+            <form method="post"
+                  action="{% url 'comunication:send_message' conversation.pk %}"
+                  class="chat-input">
+                {% csrf_token %}
+                <input type="text"
+                       name="content"
+                       placeholder="Type your message..."
+                       required />
+                <button type="submit">➤</button>
+            </form>
+        </div>
+    </section>
+{% endblock %}

--- a/templates/comunication/inbox.html
+++ b/templates/comunication/inbox.html
@@ -5,8 +5,7 @@
     StayHome
 {% endblock %}
 {% block nav_messages %}active{% endblock %}
-{% block
-    content %}
+{% block content %}
     <section class="container inbox-container">
         <h1 class="inbox-title">{% trans "Messages" %}</h1>
         {% if conversation_rows %}
@@ -20,11 +19,9 @@
                                 <div class="chat-user">
                                     <strong>
                                         {% if row.other_user.get_full_name %}
-                                            {{
-                                            row.other_user.get_full_name }}
+                                            {{ row.other_user.get_full_name }}
                                         {% else %}
-                                            {{ row.other_user.email
-                                            }}
+                                            {{ row.other_user.email }}
                                         {% endif %}
                                     </strong>
                                     <span class="chat-property">{{ row.property.title }}</span>
@@ -36,8 +33,8 @@
                             <div class="chat-preview-row">
                                 <p class="chat-preview">
                                     {% if row.last_message %}
-                                        {{ row.last_message|truncatechars:80 }} {%
-                                        else %}
+                                        {{ row.last_message|truncatechars:80 }}
+                                    {% else %}
                                         <em>{% trans "No messages yet" %}</em>
                                     {% endif %}
                                 </p>
@@ -51,8 +48,7 @@
             <div class="empty-inbox">
                 <h3>{% trans "No conversations yet" %}</h3>
                 <p>
-                    {% trans "Your messages with property owners or guests will appear here"
-                    %}.
+                    {% trans "Your messages with property owners or guests will appear here" %}.
                 </p>
             </div>
         {% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,53 +1,44 @@
 {% extends "base.html" %}
 {% load static i18n %}
-{% block title %}
-    Home |
-    StayHome
-{% endblock %}
+
+{% block title %}Home | StayHome{% endblock %}
+
 {% block content %}
-    <section class="home-hero">
-        <div class="home-hero-content">
-            <h1 class="home-hero-title">{% trans "Find Your Perfect Home" %}</h1>
-            <p class="home-hero-text">
-                {% blocktrans %} Discover properties for rent, sale, or short-term stays.
-      {% endblocktrans %}
-                {% blocktrans %}
-Connect directly with owners. {%
-endblocktrans %}
-</p>
-<form method="get" action="{% url 'properties:list_properties' %}" class="home-search-bar">
-<input type="text" name="q" placeholder="{% trans 'Search by property, owner, city, address...' %}" class="home-search-input" />
-<button type="submit" class="home-search-btn">{% trans "Search" %}</button>
-</form>
-</div>
+<section class="home-hero">
+    <div class="home-hero-content">
+        <h1 class="home-hero-title">{% trans "Find Your Perfect Home" %}</h1>
+        <p class="home-hero-text">
+            {% blocktrans %}Discover properties for rent, sale, or short-term stays.{% endblocktrans %}
+            {% blocktrans %}Connect directly with owners.{% endblocktrans %}
+        </p>
+        <form method="get" action="{% url 'properties:list_properties' %}" class="home-search-bar">
+            <input type="text" name="q" placeholder="{% trans 'Search by property, owner, city, address...' %}" class="home-search-input" />
+            <button type="submit" class="home-search-btn">{% trans "Search" %}</button>
+        </form>
+    </div>
 </section>
+
 <section>
-<h2 class="section-title">{% trans "Featured Properties" %}</h2>
-<p class="section-sub">{% trans "See what owners are listing right now" %}.</p>
-<div class="property-grid">
-{% for property in properties %}
-{% if property.image %}
-{% with
-cover=property.image.url %}
-{% include
-"partials/featured_property_card.html" %}
-{% endwith %}
-{% elif
-property.image_url %}
-{% with cover=property.image_url %}
-{% include
-"partials/featured_property_card.html" %}
-{% endwith %}
-{% else %}
-{% with
-cover="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=900&q=80"
-%}
-{% include "partials/featured_property_card.html" %}
-{% endwith %}
-{%
-endif %} {% empty %}
-<p>{% trans "No available properties" %}.</p>
-{% endfor %}
-</div>
+    <h2 class="section-title">{% trans "Featured Properties" %}</h2>
+    <p class="section-sub">{% trans "See what owners are listing right now" %}.</p>
+    <div class="property-grid">
+        {% for property in properties %}
+            {% if property.image %}
+                {% with cover=property.image.url %}
+                    {% include "partials/featured_property_card.html" %}
+                {% endwith %}
+            {% elif property.image_url %}
+                {% with cover=property.image_url %}
+                    {% include "partials/featured_property_card.html" %}
+                {% endwith %}
+            {% else %}
+                {% with cover="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=900&q=80" %}
+                    {% include "partials/featured_property_card.html" %}
+                {% endwith %}
+            {% endif %}
+        {% empty %}
+            <p>{% trans "No available properties" %}.</p>
+        {% endfor %}
+    </div>
 </section>
 {% endblock %}

--- a/templates/partials/featured_property_card.html
+++ b/templates/partials/featured_property_card.html
@@ -22,8 +22,7 @@
         <div class="card-footer">
             <div class="price-tag">
                 ${{ property.price|floatformat:0 }}
-                {% if property.listing_type ==
-                    "sale" %}
+                {% if property.listing_type == "sale" %}
                     <small>sale</small>
                 {% else %}
                     <small>/mo</small>

--- a/templates/properties/create.html
+++ b/templates/properties/create.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% load static i18n %}
 {% block title %}
-    {% trans
-    "Create Property Listing" %}
+    {% trans "Create Property Listing" %}
 {% endblock %}
 {% block content %}
     <link rel="stylesheet"
@@ -12,8 +11,7 @@
     <div class="form-card">
         <div class="form-title">{% trans "Create Property Listing" %}</div>
         <div class="form-sub">
-            {% trans "Fill in the fields and upload your property to start receiving
-            bookings!" %}
+            {% trans "Fill in the fields and upload your property to start receiving bookings!" %}
         </div>
         {% if messages %}
             <div style="background: #ecfeff;
@@ -27,117 +25,115 @@
                     {{ message }}
                     {% if not forloop.last %}
                         <br />
-                        {%
-                        endif %}
-                    {% endfor %}
-                </div>
-            {% endif %}
-            {% if form.non_field_errors %}
-                <div style="background: #fef2f2;
-                            border: 1px solid #fecaca;
-                            color: #991b1b;
-                            padding: 12px 14px;
-                            border-radius: 12px;
-                            margin-bottom: 12px;
-                            font-weight: 700">
-                    {% for error in form.non_field_errors %}
-                        {{ error }}
-                        {% if not forloop.last
-                            %}
-                            <br />
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            {% endif %}
-            <form method="post"
-                  enctype="multipart/form-data"
-                  class="form-grid"
-                  novalidate>
-                {% csrf_token %}
-                <div class="field">
-                    <label>{% trans "Title" %}</label>
-                    {{ form.title }} {{ form.title.errors }}
-                </div>
-                <div class="field">
-                    <label>{% trans "Description" %}</label>
-                    {{ form.description }} {{ form.description.errors }}
-                </div>
-                <div class="form-grid two-col">
-                    <div class="field">
-                        <label>{% trans "Address" %}</label>
-                        {{ form.address }} {{ form.address.errors }}
-                        <div id="location-results" class="location-results"></div>
-                        {{ form.city }} {{ form.latitude }} {{ form.longitude }}
-                        <div id="property-map"></div>
-                    </div>
-                    <div class="field" style="display: none">
-                        <label>{% trans "City" %}</label>
-                        {{ form.city.errors }}
-                    </div>
-                </div>
-                <div class="form-grid three-col">
-                    <div class="field">
-                        <label>{% trans "Price" %}</label>
-                        {{ form.price }} {{ form.price.errors }}
-                    </div>
-                    <div class="field">
-                        <label>{% trans "Listing type" %}</label>
-                        {{ form.listing_type }} {{ form.listing_type.errors }}
-                    </div>
-                    <div class="field">
-                        <label>{% trans "Rooms" %}</label>
-                        {{ form.rooms }} {{ form.rooms.errors }}
-                    </div>
-                    <div class="field">
-                        <label>{% trans "Bathrooms" %}</label>
-                        {{ form.bathrooms }} {{ form.bathrooms.errors }}
-                    </div>
-                    <div class="field">
-                        <label>{% trans "Area" %} (m2)</label>
-                        {{ form.square_meters }} {{ form.square_meters.errors }}
-                    </div>
-                    <div class="field">
-                        <label>{% trans "Guests capacity" %}</label>
-                        {{ form.capacity }} {{ form.capacity.errors }}
-                    </div>
-                </div>
-                <div class="form-grid two-col">
-                    <div class="field">
-                        <label>{% trans "Main photo" %} ({% trans "upload" %})</label>
-                        {{ form.image }} {{ form.image.errors }}
-                    </div>
-                    <div class="field">
-                        <label>{% trans "Main photo URL" %} ({% trans "optional" %})</label>
-                        {{ form.image_url }} {{ form.image_url.errors }}
-                    </div>
-                </div>
-                <div class="field">
-                    <label>{% trans "Blocked dates" %}</label>
-                    <input id="availability-calendar"
-                           name="availability_dates"
-                           placeholder="{% trans 'Select dates to block' %}"
-                           value="{{ request.POST.availability_dates|default:'' }}" />
-                    <small style="color: #6b7280">
-                        {% trans "If your property is for sale, do not add blocked dates." %}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% if form.non_field_errors %}
+            <div style="background: #fef2f2;
+                        border: 1px solid #fecaca;
+                        color: #991b1b;
+                        padding: 12px 14px;
+                        border-radius: 12px;
+                        margin-bottom: 12px;
+                        font-weight: 700">
+                {% for error in form.non_field_errors %}
+                    {{ error }}
+                    {% if not forloop.last %}
                         <br />
-                        {% trans "If empty, all dates will be available." %}
-                    </small>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+        <form method="post"
+              enctype="multipart/form-data"
+              class="form-grid"
+              novalidate>
+            {% csrf_token %}
+            <div class="field">
+                <label>{% trans "Title" %}</label>
+                {{ form.title }} {{ form.title.errors }}
+            </div>
+            <div class="field">
+                <label>{% trans "Description" %}</label>
+                {{ form.description }} {{ form.description.errors }}
+            </div>
+            <div class="form-grid two-col">
+                <div class="field">
+                    <label>{% trans "Address" %}</label>
+                    {{ form.address }} {{ form.address.errors }}
+                    <div id="location-results" class="location-results"></div>
+                    {{ form.city }} {{ form.latitude }} {{ form.longitude }}
+                    <div id="property-map"></div>
                 </div>
-                <div class="submit-bar">
-                    <button type="submit" class="btn-list">{% trans "Save listing" %}</button>
+                <div class="field" style="display: none">
+                    <label>{% trans "City" %}</label>
+                    {{ form.city.errors }}
                 </div>
-            </form>
-        </div>
-        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
-        <script src="{% static 'js/property_location.js' %}"></script>
-        <script>
-  flatpickr("#availability-calendar", {
+            </div>
+            <div class="form-grid three-col">
+                <div class="field">
+                    <label>{% trans "Price" %}</label>
+                    {{ form.price }} {{ form.price.errors }}
+                </div>
+                <div class="field">
+                    <label>{% trans "Listing type" %}</label>
+                    {{ form.listing_type }} {{ form.listing_type.errors }}
+                </div>
+                <div class="field">
+                    <label>{% trans "Rooms" %}</label>
+                    {{ form.rooms }} {{ form.rooms.errors }}
+                </div>
+                <div class="field">
+                    <label>{% trans "Bathrooms" %}</label>
+                    {{ form.bathrooms }} {{ form.bathrooms.errors }}
+                </div>
+                <div class="field">
+                    <label>{% trans "Area" %} (m2)</label>
+                    {{ form.square_meters }} {{ form.square_meters.errors }}
+                </div>
+                <div class="field">
+                    <label>{% trans "Guests capacity" %}</label>
+                    {{ form.capacity }} {{ form.capacity.errors }}
+                </div>
+            </div>
+            <div class="form-grid two-col">
+                <div class="field">
+                    <label>{% trans "Main photo" %} ({% trans "upload" %})</label>
+                    {{ form.image }} {{ form.image.errors }}
+                </div>
+                <div class="field">
+                    <label>{% trans "Main photo URL" %} ({% trans "optional" %})</label>
+                    {{ form.image_url }} {{ form.image_url.errors }}
+                </div>
+            </div>
+            <div class="field">
+                <label>{% trans "Blocked dates" %}</label>
+                <input id="availability-calendar"
+                       name="availability_dates"
+                       placeholder="{% trans 'Select dates to block' %}"
+                       value="{{ request.POST.availability_dates|default:'' }}" />
+                <small style="color: #6b7280">
+                    {% trans "If your property is for sale, do not add blocked dates." %}
+                    <br />
+                    {% trans "If empty, all dates will be available." %}
+                </small>
+            </div>
+            <div class="submit-bar">
+                <button type="submit" class="btn-list">{% trans "Save listing" %}</button>
+            </div>
+        </form>
+    </div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script src="{% static 'js/property_location.js' %}"></script>
+    <script>
+flatpickr("#availability-calendar", {
     mode: "multiple",
     dateFormat: "Y-m-d",
     altInput: true,
     altFormat: "F j, Y",
     minDate: "today",
-  });
-        </script>
-    {% endblock %}
+});
+    </script>
+{% endblock %}

--- a/templates/properties/detail.html
+++ b/templates/properties/detail.html
@@ -16,65 +16,65 @@
                     <span class="pill pill-blue">{{ availability_label }}</span>
                     <span class="pill pill-dark">{{ property.get_listing_type_display }}</span>
                 </div>
-                <div class="media-body">
-                    <h1 class="title">{{ property.title }}</h1>
-                    <p class="owner">Owner: {{ property.owner.user.first_name }} {{ property.owner.user.last_name }}</p>
-                    <p class="sub">{{ property.address|default:property.city }}</p>
-                    <p class="price">
-                        ${{ property.price }}
-                        {% if property.listing_type == "sale" %}
-                            <small class="price-period">sale price</small>
-                        {% else %}
-                            <small class="price-period">/mo</small>
-                        {% endif %}
-                    </p>
-                    <p class="description">{{ property.description|default:"No description provided." }}</p>
-                    {% if user.is_authenticated and not has_sale_contract %}
-                        <form method="post"
-                              action="{% url 'properties:toggle_saved_property' property.pk %}">
-                            {% csrf_token %}
-                            <input type="hidden" name="next" value="{{ request.path }}">
-                            <button type="submit" class="cta-btn">
-                                {% if is_saved %}
-                                    Remove from saved
-                                {% else %}
-                                    {% if property.listing_type == "sale" %}
-                                        Save to wishlist
-                                    {% else %}
-                                        Save to favorites
-                                    {% endif %}
-                                {% endif %}
-                            </button>
-                        </form>
-                    {% elif not user.is_authenticated and not has_sale_contract %}
-                        <a href="{% url 'login' %}?next={{ request.path }}" class="cta-btn">Log in to save this property</a>
+            </div>
+            <div class="media-body">
+                <h1 class="title">{{ property.title }}</h1>
+                <p class="owner">Owner: {{ property.owner.user.first_name }} {{ property.owner.user.last_name }}</p>
+                <p class="sub">{{ property.address|default:property.city }}</p>
+                <p class="price">
+                    ${{ property.price }}
+                    {% if property.listing_type == "sale" %}
+                        <small class="price-period">sale price</small>
+                    {% else %}
+                        <small class="price-period">/mo</small>
                     {% endif %}
-                    <div class="contact-owner" style="margin-top:20px;">
-                        {% if request.user.is_authenticated and request.user != property.owner.user and can_contact_owner %}
-                            <form method="post"
-                                  action="{% url 'comunication:start_conversation' property.pk %}">
-                                {% csrf_token %}
-                                <button type="submit" class="cta-btn">Contact Owner</button>
-                            </form>
-                        {% elif not request.user.is_authenticated and property.listing_type == "sale" and not has_sale_contract %}
-                            <a href="{% url 'login' %}?next={% url 'properties:property_detail' property.pk %}"
-                               class="cta-btn">Log in to contact owner</a>
-                        {% endif %}
-                    </div>
-                    <div class="specs">
-                        <span>&#128719; {{ property.rooms }} rooms</span>
-                        <span>&#128703; {{ property.bathrooms }} baths</span>
-                        <span>&#128208; {{ property.square_meters|default:"--" }} m2</span>
-                        <span>&#128101; {{ property.capacity }} guests</span>
-                        <span>&#128197; {{ property.availability_dates|default:"All dates available" }}</span>
-                    </div>
-                    {% if property.latitude and property.longitude %}
-                        <section class="location-section">
-                            <h2 class="location-section-title">Where is it located?</h2>
-                            <div id="detail-map"></div>
-                        </section>
+                </p>
+                <p class="description">{{ property.description|default:"No description provided." }}</p>
+                {% if user.is_authenticated and not has_sale_contract %}
+                    <form method="post"
+                          action="{% url 'properties:toggle_saved_property' property.pk %}">
+                        {% csrf_token %}
+                        <input type="hidden" name="next" value="{{ request.path }}">
+                        <button type="submit" class="cta-btn">
+                            {% if is_saved %}
+                                Remove from saved
+                            {% else %}
+                                {% if property.listing_type == "sale" %}
+                                    Save to wishlist
+                                {% else %}
+                                    Save to favorites
+                                {% endif %}
+                            {% endif %}
+                        </button>
+                    </form>
+                {% elif not user.is_authenticated and not has_sale_contract %}
+                    <a href="{% url 'login' %}?next={{ request.path }}" class="cta-btn">Log in to save this property</a>
+                {% endif %}
+                <div class="contact-owner" style="margin-top:20px;">
+                    {% if request.user.is_authenticated and request.user != property.owner.user and can_contact_owner %}
+                        <form method="post"
+                              action="{% url 'comunication:start_conversation' property.pk %}">
+                            {% csrf_token %}
+                            <button type="submit" class="cta-btn">Contact Owner</button>
+                        </form>
+                    {% elif not request.user.is_authenticated and property.listing_type == "sale" and not has_sale_contract %}
+                        <a href="{% url 'login' %}?next={% url 'properties:property_detail' property.pk %}"
+                           class="cta-btn">Log in to contact owner</a>
                     {% endif %}
                 </div>
+                <div class="specs">
+                    <span>&#128719; {{ property.rooms }} rooms</span>
+                    <span>&#128703; {{ property.bathrooms }} baths</span>
+                    <span>&#128208; {{ property.square_meters|default:"--" }} m2</span>
+                    <span>&#128101; {{ property.capacity }} guests</span>
+                    <span>&#128197; {{ property.availability_dates|default:"All dates available" }}</span>
+                </div>
+                {% if property.latitude and property.longitude %}
+                    <section class="location-section">
+                        <h2 class="location-section-title">Where is it located?</h2>
+                        <div id="detail-map"></div>
+                    </section>
+                {% endif %}
             </div>
         </div>
         {% if property.listing_type == "sale" %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}Login – StayHome{% endblock %}
-{%
-load static i18n %}
+{% load static i18n %}
 {% block content %}
     <div class="page">
         <div class="card auth-card">

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,5 +1,2 @@
 {% load static i18n %}
-{% trans "We received a request to reset your password on
-StayHome." %} {% trans "Click the following link:" %} {{ protocol }}://{{ domain
-}}{% url 'password_reset_confirm' uidb64=uid token=token %} {% trans "If this
-wasn't you, you can ignore this message." %}
+{% trans "We received a request to reset your password on StayHome." %} {% trans "Click the following link:" %} {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %} {% trans "If this wasn't you, you can ignore this message." %}

--- a/transactions/models.py
+++ b/transactions/models.py
@@ -1,7 +1,24 @@
 from django.conf import settings
 from django.db import models
+from django.utils import timezone
 
 from core.models import SoftDeleteModel, TimeStampedModel
+
+
+class ContractQuerySet(models.QuerySet):
+    def with_property_details(self):
+        return self.select_related(
+            "property",
+            "property__owner",
+            "property__owner__user",
+        )
+
+    def purchased_by(self, user):
+        return (
+            self.filter(tenant=user, type=Contract.TYPE_SALE)
+            .with_property_details()
+            .order_by("-created_at")
+        )
 
 
 class Contract(TimeStampedModel, SoftDeleteModel):
@@ -40,8 +57,35 @@ class Contract(TimeStampedModel, SoftDeleteModel):
         blank=True,
     )
 
+    objects = ContractQuerySet.as_manager()
+
     def __str__(self):
         return f"Contract {self.pk} - {self.type} - {self.property}"
+
+
+class BookingQuerySet(models.QuerySet):
+    def with_property_details(self):
+        return self.select_related(
+            "property",
+            "property__owner",
+            "property__owner__user",
+        )
+
+    def for_user(self, user):
+        return self.filter(user=user).with_property_details()
+
+    def client_context(self, user):
+        today = timezone.localdate()
+        bookings = self.for_user(user)
+        return {
+            "pending": bookings.filter(status=Booking.STATUS_PENDING),
+            "approved": bookings.filter(
+                status=Booking.STATUS_APPROVED,
+                check_in__gte=today,
+            ),
+            "rejected": bookings.filter(status=Booking.STATUS_REJECTED),
+            "cancelled": bookings.filter(status=Booking.STATUS_CANCELLED),
+        }
 
 
 class Booking(TimeStampedModel):
@@ -74,6 +118,8 @@ class Booking(TimeStampedModel):
         choices=STATUS_CHOICES,
         default=STATUS_PENDING,
     )
+
+    objects = BookingQuerySet.as_manager()
 
     class Meta:
         ordering = ["-created_at"]

--- a/transactions/selectors.py
+++ b/transactions/selectors.py
@@ -1,51 +1,15 @@
-from django.utils import timezone
-
 from .models import Booking, Contract
 
 
 def has_sale_contract(property_obj, buyer=None):
-    contracts = Contract.objects.filter(
-        property=property_obj,
-        type=Contract.TYPE_SALE,
-    )
-    if buyer is not None:
-        contracts = contracts.filter(tenant=buyer)
-    return contracts.exists()
+    return property_obj.has_sale_contract(buyer=buyer)
 
 
 def can_access_property(user, property_obj):
-    if not has_sale_contract(property_obj):
-        return True
-
-    if not getattr(user, "is_authenticated", False):
-        return False
-
-    if property_obj.owner and property_obj.owner.user_id == user.id:
-        return True
-
-    return has_sale_contract(property_obj, buyer=user)
+    return property_obj.can_be_accessed_by(user)
 
 
 def get_client_bookings_context(user):
-    today = timezone.localdate()
-    bookings = Booking.objects.filter(user=user).select_related(
-        "property",
-        "property__owner",
-        "property__owner__user",
-    )
-    purchased_contracts = (
-        Contract.objects.filter(tenant=user, type=Contract.TYPE_SALE)
-        .select_related("property", "property__owner", "property__owner__user")
-        .order_by("-created_at")
-    )
-
-    return {
-        "pending": bookings.filter(status=Booking.STATUS_PENDING),
-        "approved": bookings.filter(
-            status=Booking.STATUS_APPROVED,
-            check_in__gte=today,
-        ),
-        "rejected": bookings.filter(status=Booking.STATUS_REJECTED),
-        "cancelled": bookings.filter(status=Booking.STATUS_CANCELLED),
-        "purchased_contracts": purchased_contracts,
-    }
+    context = Booking.objects.client_context(user)
+    context["purchased_contracts"] = Contract.objects.purchased_by(user)
+    return context


### PR DESCRIPTION
## Summary

Addresses the professor's feedback on point 4 (selectors as a flat module) by moving the stateless selector functions into queryset managers and instance methods, making the code more expressive. Also includes fixes for unrelated template and layout bugs found while testing.

## Changes

### Refactor — `properties` selectors into managers
- Moved `list_available_properties` to `PropertyQuerySet.search`
- Moved `get_property_detail` to `PropertyQuerySet.detail`
- Added `ids_for_user`, `favorites_for`, and `wishlist_for` methods to `SavedPropertyQuerySet`
- Extended `Property.has_sale_contract` to accept an optional `buyer` argument
- Added `Property.can_be_accessed_by` instance method
- Kept `properties/selectors.py` as a thin delegation layer to avoid breaking existing imports in views and services

### Refactor — `transactions` selectors into managers
- Added `BookingQuerySet` with `for_user` and `client_context` methods
- Added `ContractQuerySet` with a `purchased_by` method
- Kept `transactions/selectors.py` as a thin delegation layer

### Fix — Template syntax errors
Several templates had Django tags `{% ... %}` split across multiple lines, which caused `TemplateSyntaxError` on Django 6 (for example, a broken `{% load i18n %}` made every `{% trans %}` fail). Normalized all tags to a single line in:
- `home.html`, `partials/featured_property_card.html`
- `registration/login.html`, `registration/password_reset_email.html`
- `auth/password_reset.html`, `auth/password_reset_done.html`, `auth/password_reset_complete.html`
- `comunication/inbox.html`, `comunication/conversation_detail.html`
- `properties/create.html`

### Fix — Property detail page layout
Moved `.media-body` out of `.hero-media` in `properties/detail.html`. The CSS expects them as siblings, so having them nested caused the title, price, and description to render on top of the background image.

## Examples of the new expressive API

| Before | After |
|---|---|
| `has_sale_contract(property_obj)` | `property_obj.has_sale_contract()` |
| `can_access_property(user, property_obj)` | `property_obj.can_be_accessed_by(user)` |
| `get_property_detail(pk)` | `Property.objects.detail(pk=pk)` |
| `get_user_favorites(user)` | `SavedProperty.objects.favorites_for(user)` |
| `list_available_properties(filters)` | `Property.objects.search(filters)` |

## Notes
- No views or services were modified — the selector modules remain as thin delegation layers, so the rest of the codebase keeps working without changes.
- A pending migration (`0005_booking_updated_at`) needs to be applied with `python manage.py migrate` after pulling.