### PR TITLE
refactor(bookings): centralize booking statuses with TextChoices

### DIFF
--- a/comunication/views.py
+++ b/comunication/views.py
@@ -48,7 +48,9 @@ def start_conversation(request, property_id):
     # -----------------------------
 
     approved_booking = Booking.objects.filter(
-        property=property_obj, user=buyer_user, status="approved"
+        property=property_obj,
+        user=buyer_user,
+        status=Booking.STATUS_APPROVED,
     ).exists()
 
     purchased_property = has_sale_contract(property_obj, buyer=buyer_user)

--- a/properties/models.py
+++ b/properties/models.py
@@ -82,8 +82,10 @@ class Property(models.Model):
         if self.listing_type == "sale":
             return False
 
+        from transactions.models import Booking
+
         return self.bookings.filter(
-            status="approved",
+            status=Booking.STATUS_APPROVED,
             check_in__lt=end_date,
             check_out__gt=start_date,
         ).exists()

--- a/transactions/models.py
+++ b/transactions/models.py
@@ -45,17 +45,16 @@ class Contract(TimeStampedModel, SoftDeleteModel):
 
 
 class Booking(TimeStampedModel):
-    STATUS_PENDING = "pending"
-    STATUS_APPROVED = "approved"
-    STATUS_REJECTED = "rejected"
-    STATUS_CANCELLED = "cancelled"
+    class Status(models.TextChoices):
+        PENDING = "pending", "Pending"
+        APPROVED = "approved", "Approved"
+        REJECTED = "rejected", "Rejected"
+        CANCELLED = "cancelled", "Cancelled"
 
-    STATUS_CHOICES = [
-        (STATUS_PENDING, "Pending"),
-        (STATUS_APPROVED, "Approved"),
-        (STATUS_REJECTED, "Rejected"),
-        (STATUS_CANCELLED, "Cancelled"),
-    ]
+    STATUS_PENDING = Status.PENDING
+    STATUS_APPROVED = Status.APPROVED
+    STATUS_REJECTED = Status.REJECTED
+    STATUS_CANCELLED = Status.CANCELLED
 
     property = models.ForeignKey(
         "properties.Property",
@@ -71,8 +70,8 @@ class Booking(TimeStampedModel):
     check_out = models.DateField()
     status = models.CharField(
         max_length=20,
-        choices=STATUS_CHOICES,
-        default=STATUS_PENDING,
+        choices=Status,
+        default=Status.PENDING,
     )
 
     class Meta:


### PR DESCRIPTION
## Summary
- centralize Booking statuses using Django TextChoices
- preserve compatibility with existing Booking.STATUS_* constants
- replace backend literal approved status checks with model constants

## Scope
- only 3 backend files changed
- no template or UI status-string refactor included
- no migration added in this PR